### PR TITLE
Add FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # codex-test
-csd4
+
+This repository contains a minimal skeleton to start a FastAPI project.
+
+## Running the application
+
+Install dependencies and run the server with Uvicorn:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+The application exposes a single `/` route that returns a simple JSON greeting.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"Hello": "World"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- scaffold FastAPI project with minimal `app/main.py`
- add `requirements.txt`
- document running instructions in README
- ignore Python cache files

## Testing
- `python -m py_compile app/main.py`