### PR TITLE
Add FastAPI MySQL example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # codex-test
-csd4
+
+This repository contains a minimal skeleton to start a FastAPI project backed by a MySQL database.
+
+## Running the application
+
+Install dependencies and run the server with Uvicorn:
+
+```bash
+pip install -r requirements.txt
+python -m app.main
+```
+
+Update `app/database.py` with your local MySQL credentials before starting. The application exposes a `/items` route that returns all items stored in the database.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "mysql+aiomysql://user:password@localhost:3306/testdb"
+
+engine = create_async_engine(DATABASE_URL, echo=True)
+SessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,42 @@
+from typing import AsyncGenerator
+
+from fastapi import Depends, FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import uvicorn
+
+from .database import Base, engine, SessionLocal
+from .models import Item
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with SessionLocal() as session:
+        yield session
+
+
+@app.get("/")
+async def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items")
+async def read_items(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Item))
+    items = result.scalars().all()
+    return items
+
+
+def main() -> None:
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .database import Base
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    price = Column(Integer, nullable=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+aiomysql


### PR DESCRIPTION
## Summary
- connect FastAPI to local MySQL with SQLAlchemy
- create `Item` model and expose `/items` endpoint
- include helper to run server via `python -m app.main`
- document MySQL setup and add dependencies

## Testing
- `python -m py_compile app/main.py app/database.py app/models.py`
